### PR TITLE
Create manifests and blocks in yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Google Slides to Schema
+# Google Slides to Manifest
 
-Utility for converting Google Slides to EQ Schema JSON files
+Utility for converting Google Slides to EQ YAML manifest and block files
 
 ## Setup
 Based on python 3
@@ -36,16 +36,16 @@ For help using:
 Example with the id of a Google Slides presentation to convert and
 output file:
 ```
-python convert.py --presentation_id=[...] --out=survey.json
+python convert.py --presentation_id=[...] --survey_title=[...] --survey_variant=[...]
 ```
 
-You will need to authorise the project to access Google Slides with
+You will need to authorize the project to access Google Slides with
 a valid Google account that has access the presentations you want
 to process. This is separate from the API access and is requested
 at runtime.
 
 ## Presentation Format
-In order to extract content from the Slides into a schema some
+In order to extract content from the Slides into a manifest some
 conventions need to be followed.
 
 Primarily the system uses the font-size to differentiate between
@@ -58,8 +58,8 @@ Element | Font Size (pt)
 ------- | --------------
 Interstitial Title | 30
 Interstitial Description | 22
-Section Title | 24
-Section Description | 22
+Block Title | 24
+Block Description | 22
 Question Title | 20
 Question Description | 18
 Question Guidance | 16
@@ -77,27 +77,27 @@ Guidance Description | none
 Guidance List Item | bullet-list
 
 Any text that is not BLACK is ignored (for example so that notes can be
-added to slides as blue-text without affecting the schema). Note that
-if text isn't appearing in the schema and looks BLACK in Google Slides
+added to slides as blue-text without affecting the manifest). Note that
+if text isn't appearing in the manifest and looks BLACK in Google Slides
 it may actually be a shade of grey, check the colour is set correctly.
 
-Answer types are determined based on the existance of shapes on the
+Answer types are determined based on the existence of shapes on the
 slide as follows:
 
 Type | Shape
 ---- | -----
-Radio | Ellipse (Cirlce)    
+Radio | Ellipse (Circle)    
 Checkbox | Rectangle with RED outline
 Currency | Rounded Rectangle
 Comments | Rectangle with GREEN outline
 Numeric | N/A - Assumed if none of the above shapes seen
 
 Any slides with the NO_SMOKING shape on it will be ignored completely,
-useful for non-questionnare slides, such as notes etc.
+useful for non-questionnaire slides, such as notes etc.
 
 Questionnaire groups are generated for each interstitial encountered;
 all questionnaire blocks since the last interstitial up to and include
-the next interstitial are included in the group. The section title
+the next interstitial are included in the group. The block title
 on the interstitial is used as the group title.
 
 ## Example Google Slide Presentation

--- a/auth.py
+++ b/auth.py
@@ -8,7 +8,7 @@ from oauth2client.file import Storage
 # at ~/.credentials/
 SCOPES = 'https://www.googleapis.com/auth/presentations.readonly'
 CLIENT_SECRET_FILE = 'client_secret.json'
-APPLICATION_NAME = 'Google Slides to EQ JSON Schema'
+APPLICATION_NAME = 'Google Slides to EQ YAML Manifests/Blocks'
 
 
 def auth_http(flags):

--- a/extract.py
+++ b/extract.py
@@ -87,10 +87,10 @@ def _get_type(content, style, paragraph_marker):
         element_type = 'interstitial_title'
     elif _is_interstitial_description(style):
         element_type = 'interstitial_description'
-    elif _is_section_title(style):
-        element_type = 'section_title'
-    elif _is_section_description(style):
-        element_type = 'section_description'
+    elif _is_block_title(style):
+        element_type = 'block_title'
+    elif _is_block_description(style):
+        element_type = 'block_description'
     elif _is_question_title(style):
         element_type = 'question_title'
     elif _is_question_guidance_title(style, paragraph_marker):
@@ -157,12 +157,13 @@ def _is_currency(shape):
 
 def _ignore_text(content, style):
     """ Check if this content should be ignored; i.e. isn't BLACK text """
+    non_black_color = {'red': 0.13333334, 'blue': 0.13333334, 'green': 0.13333334}
     if not content:
         return True
 
     rgb_color = get_dict_nested_value(style, 'foregroundColor', 'opaqueColor', 'rgbColor')
 
-    if not rgb_color or len(rgb_color) == 0:
+    if not rgb_color or len(rgb_color) == 0 or rgb_color == non_black_color:
         return False
     else:
         return True
@@ -176,12 +177,12 @@ def _is_interstitial_description(style):
     return _is_font_size(style, 28)
 
 
-def _is_section_title(style):
+def _is_block_title(style):
     return _is_font_size(style, 24)
 
 
-def _is_section_description(style):
-    return _is_font_size(style, 22)
+def _is_block_description(style):
+     return _is_font_size(style, 22)
 
 
 def _is_question_title(style):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+PyYAML
 google-api-python-client

--- a/utils.py
+++ b/utils.py
@@ -11,5 +11,5 @@ def get_dict_nested_value(x, *keys):
     for k in keys:
         x = x.get(k)
         if not x:
-            return None
+            return {}
     return x


### PR DESCRIPTION
What is the context of this PR?

Trello card: https://trello.com/c/7H8exk7u

Convert in this repo used to convert google slides in JSON schemas. Now to match updated schema variants, Convert produces yam manifest files of surveys and also individual block files, only reproducing variants of the same titled block.

How to review

Follow README and set up and enter two variants of the same survey from Google slides. A manifest file should be produced and all blocks within said survey in a Blocks folder.
use: 
python convert.py --presentation_id=[PRESENTATION_ID] --manifest_out=[MANIFEST_SURVEY] --survey_variant=[SURVEY_VARIANT]